### PR TITLE
Add clipboard support back for both FF / Chrome

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,8 +10,24 @@ function updateTabs(message) {
     });
 }
 
+function convertBlobToArrayBuffer(blob) {
+    return new Response(blob).arrayBuffer();
+}
+
 browser.runtime.onMessage.addListener((message, sender, respond) => {
     switch (message.type) {
+        case "fileToClip":
+            // Chromium does not implement this API
+            // due to clipboard being manipulatable from the client.
+            if (!!browser?.clipboard?.setImageData) {
+                convertBlobToArrayBuffer(message.blob).then(arrayBuffer => {
+                    browser.clipboard.setImageData(arrayBuffer, "png");
+                    respond({ status: "success"});
+                }).catch(error => { respond({status: 'failed'}) });
+            } else {
+                respond({ status: 'failed'});
+            }
+            break;
         case "config":
             console.log("new config");
             config = message.config;

--- a/manifest.json
+++ b/manifest.json
@@ -45,7 +45,8 @@
   "permissions": [
     "storage",
     "tabs",
-    "https://raw.githubusercontent.com/*"
+    "https://raw.githubusercontent.com/*",
+    "clipboardWrite"
   ],
   "options_ui": {
     "open_in_tab": true,

--- a/styles/invasion.css
+++ b/styles/invasion.css
@@ -86,3 +86,7 @@
 .yellow {
     border-color: #c1ba0b;
 }
+
+.hidden {
+    display: none;
+}


### PR DESCRIPTION
Adds back in support for putting the image directly on the clipboard, with fallback support.

Chromium will use the client side clipboard manipulation APIs. Firefox will use the exposed `setImageData` on the background script via a post message.